### PR TITLE
Add Github Action for gh-pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+# This is a basic gh-pages deploy workflow that is triggered on new commits on development branch
+name: Gatsby Publish
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          deploy-branch: master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ name: Gatsby Publish
 on:
   push:
     branches:
-      - development
+      - source
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "analyze": "source-map-explorer 'public/*.js'",
     "build": "gatsby build",
     "clean": "gatsby clean",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public",
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public -b master",
     "dev": "gatsby develop",
     "format": "prettier --write \"src/**/*.{ts,tsx,md}\"",
     "lint": "eslint 'src/**/*.{ts,tsx}'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7668,7 +7668,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-pages@3.2.3:
+gh-pages@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-3.2.3.tgz#897e5f15e111f42af57d21d430b83e5cdf29472c"
   integrity sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7668,7 +7668,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-pages@^3.2.3:
+gh-pages@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-3.2.3.tgz#897e5f15e111f42af57d21d430b83e5cdf29472c"
   integrity sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==


### PR DESCRIPTION
Closes #139 

Worked in [my repo](https://github.com/triszt4n/triszt4n.github.io). This will require a new workflow for the project transfer:
1. transfer via GitHub Transfer repository
2. rename old ftsrg.github.io to old.ftsrg.github.io
2. rename newly transferred repo to ftsrg.github.io
3. create org PAT and add PAT as a secret in Settings > Secrets
4. re-run deploy action
5. check if deployment successful
6. Add CNAME file on development branch
5. kir-dev forks the repository, renames to ftsrg-next