### PR TITLE
Remove cookie banner overlay

### DIFF
--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -30,17 +30,17 @@ const CookieBanner: React.FC<Props> = ({ onAccept, onReject }) => {
 
   return (
     <CookieConsent
-      overlay={false}
+      overlay
       location="top"
       enableDeclineButton
       buttonText={t('commons.cookiePolicy.accept')}
       declineButtonText={t('commons.cookiePolicy.decline')}
       cookieName={COOKIE_CONSENT_NAME}
       expires={150}
-      style={{ position: 'relative' }}
+      style={{}}
       containerClasses="cookie-banner"
       disableButtonStyles
-      overlayClasses="site-overlay"
+      overlayClasses="cookie-overlay"
       buttonClasses="btn btn-primary"
       declineButtonClasses="btn btn-secondary"
       onAccept={() => {

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -30,14 +30,14 @@ const CookieBanner: React.FC<Props> = ({ onAccept, onReject }) => {
 
   return (
     <CookieConsent
-      overlay
-      location="bottom"
+      overlay={false}
+      location="top"
       enableDeclineButton
       buttonText={t('commons.cookiePolicy.accept')}
       declineButtonText={t('commons.cookiePolicy.decline')}
       cookieName={COOKIE_CONSENT_NAME}
       expires={150}
-      style={{}}
+      style={{ position: 'relative' }}
       containerClasses="cookie-banner"
       disableButtonStyles
       overlayClasses="site-overlay"

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -31,7 +31,7 @@ const CookieBanner: React.FC<Props> = ({ onAccept, onReject }) => {
   return (
     <CookieConsent
       overlay
-      location="top"
+      location="bottom"
       enableDeclineButton
       buttonText={t('commons.cookiePolicy.accept')}
       declineButtonText={t('commons.cookiePolicy.decline')}

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -18,14 +18,12 @@ const Layout: React.FC<PropsWithChildren<Props>> = ({ href, seo, children }) => 
     <CookieContext.Provider value={cookieState}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <SEO {...seo} />
-      <div className="page-wrapper">
-        <CookieBanner onAccept={() => setCookieState(true)} onReject={() => setCookieState(false)} />
-        <div className="d-flex flex-column bg-light page-content">
-          <NavBar href={href} />
-          <main className="flex-grow-1 site-wrapper">{children}</main>
-          <Footer hasContact />
-          <div className="d-none">Current version: GITHUB_COMMIT_URL_HERE</div>
-        </div>
+      <CookieBanner onAccept={() => setCookieState(true)} onReject={() => setCookieState(false)} />
+      <div className="d-flex flex-column bg-light">
+        <NavBar href={href} />
+        <main className="flex-grow-1 site-wrapper">{children}</main>
+        <Footer hasContact />
+        <div className="d-none">Current version: GITHUB_COMMIT_URL_HERE</div>
       </div>
     </CookieContext.Provider>
   )

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -18,13 +18,13 @@ const Layout: React.FC<PropsWithChildren<Props>> = ({ href, seo, children }) => 
     <CookieContext.Provider value={cookieState}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <SEO {...seo} />
-      <CookieBanner onAccept={() => setCookieState(true)} onReject={() => setCookieState(false)} />
       <div className="d-flex flex-column bg-light">
         <NavBar href={href} />
         <main className="flex-grow-1 site-wrapper">{children}</main>
         <Footer hasContact />
         <div className="d-none">Current version: GITHUB_COMMIT_URL_HERE</div>
       </div>
+      <CookieBanner onAccept={() => setCookieState(true)} onReject={() => setCookieState(false)} />
     </CookieContext.Provider>
   )
 }

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -18,13 +18,15 @@ const Layout: React.FC<PropsWithChildren<Props>> = ({ href, seo, children }) => 
     <CookieContext.Provider value={cookieState}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <SEO {...seo} />
-      <div className="d-flex flex-column bg-light">
-        <NavBar href={href} />
-        <main className="flex-grow-1 site-wrapper">{children}</main>
-        <Footer hasContact />
-        <div className="d-none">Current version: GITHUB_COMMIT_URL_HERE</div>
+      <div className="page-wrapper">
+        <CookieBanner onAccept={() => setCookieState(true)} onReject={() => setCookieState(false)} />
+        <div className="d-flex flex-column bg-light page-content">
+          <NavBar href={href} />
+          <main className="flex-grow-1 site-wrapper">{children}</main>
+          <Footer hasContact />
+          <div className="d-none">Current version: GITHUB_COMMIT_URL_HERE</div>
+        </div>
       </div>
-      <CookieBanner onAccept={() => setCookieState(true)} onReject={() => setCookieState(false)} />
     </CookieContext.Provider>
   )
 }

--- a/src/utils/scss/_site-base.scss
+++ b/src/utils/scss/_site-base.scss
@@ -40,6 +40,17 @@ h5,
   font-family: $font-family-sans-serif;
 }
 
+.page-wrapper {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100vh;
+}
+
+.page-wrapper > .page-content {
+  overflow: auto;
+}
+
 .site-wrapper {
   background-color: white;
 }

--- a/src/utils/scss/_site-base.scss
+++ b/src/utils/scss/_site-base.scss
@@ -40,23 +40,8 @@ h5,
   font-family: $font-family-sans-serif;
 }
 
-.page-wrapper {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  height: 100vh;
-}
-
-.page-wrapper > .page-content {
-  overflow: auto;
-}
-
 .site-wrapper {
   background-color: white;
-}
-
-.site-overlay {
-  background-color: rgba($black, 0.7) !important;
 }
 
 .text-black {

--- a/src/utils/scss/_site-cookiebanner.scss
+++ b/src/utils/scss/_site-cookiebanner.scss
@@ -5,3 +5,7 @@
     margin-right: 1em;
   }
 }
+
+.cookie-overlay {
+  background-color: rgba($black, 0.7) !important;
+}


### PR DESCRIPTION
If a user visited the site while using content blockers (specifically cookie consent blockers), in some cases the cookie banner was removed, but the overlay of the banner was left behind. As the banner was removed, there was no way to interact with the site, rendering it unusable.

Confirmed with:
- Brave Browser