### PR TITLE
Remove Twitter integration

### DIFF
--- a/src/components/indexpage-components/NewsSection.tsx
+++ b/src/components/indexpage-components/NewsSection.tsx
@@ -18,19 +18,13 @@ const NewsSection: React.FC = () => {
       <div id="news" className="news-updates" key={key}>
         <Helmet>
           <script defer crossOrigin="anonymous" src="https://connect.facebook.net/hu_HU/sdk.js#xfbml=1&version=v7.0" nonce="SRkXDokT" />
-          <script defer crossOrigin="anonymous" src="https://platform.twitter.com/widgets.js" />
         </Helmet>
         <Container>
           <h2 className="section-title-underline text-center mb-5">
             <span>{t('home.news.title')}</span>
           </h2>
           <Row className="justify-content-center text-center mb-5">
-            <Col lg={6} className="social-media-container mb-5 mb-lg-0">
-              <a className="twitter-timeline" data-width="400" data-height="500" href="https://twitter.com/ftsrg_bme?ref_src=twsrc%5Etfw">
-                {t('commons.ftsrgFullName')} on Twitter
-              </a>
-            </Col>
-            <Col lg={6} className="social-media-container">
+            <Col lg={12} className="social-media-container">
               <div
                 className="fb-page"
                 data-href="https://www.facebook.com/ftsrg/"

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -3,7 +3,7 @@ import { Link, useI18next } from 'gatsby-plugin-react-i18next'
 import React from 'react'
 import AnchorLink from 'react-anchor-link-smooth-scroll'
 import { Button, Col, Container, Nav, NavDropdown, Navbar, Row } from 'react-bootstrap'
-import { FaFacebookF, FaGithub, FaTwitter } from 'react-icons/fa'
+import { FaFacebookF, FaGithub, FaLinkedinIn } from 'react-icons/fa'
 import LanguageToggle from './LanguageToggle'
 import NAVBAR_ITEMS from './navbar-items'
 
@@ -119,9 +119,9 @@ const NavBar: React.FC<Props> = ({ href }) => {
                 as="a"
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://twitter.com/ftsrg_bme"
+                href="https://hu.linkedin.com/company/ftsrg"
               >
-                <FaTwitter />
+                <FaLinkedinIn />
               </Button>
               <Button
                 className="rounded-0 me-1"


### PR DESCRIPTION
This pull request aims to replace Twitter integration, in favor of LinkedIn. The icon in the NavBar is replaced, while the feed is removed. (For more info, see #345)